### PR TITLE
Makefiles for easier startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 APP_NAME=SIGMA
-APP_URL=http://127.0.0.1
-APP_ENV=production
+APP_URL=http://localhost:8000
+APP_ENV=development
 APP_KEY=# generate with php artisan key:generate
-APP_DEBUG=false
+APP_DEBUG=true
 APP_CURRENCY=EUR
 APP_CURRENCY_SYMBOL="€"
 DEBUGBAR_ENABLED=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM dunglas/frankenphp
+FROM dunglas/frankenphp:php8.4
 
-# Arguments defined in docker-compose.yml
-ARG user
-ARG uid
+ENV NODE_VERSION=24
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -30,14 +28,25 @@ RUN install-php-extensions \
     gd
 
 # Get latest Composer
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
-# Create system user to run Composer and Artisan Commands
-RUN useradd -G www-data,root -u $uid -d /home/$user $user
-RUN mkdir -p /home/$user/.composer && \
-    chown -R $user:$user /home/$user
+# Install node and NPM
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir $NVM_DIR \
+    && curl https://raw.githubusercontent.com/creationix/nvm/v0.40.6/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default \
+    && ln -s $NVM_DIR/versions/node/$(nvm version $NODE_VERSION) $NVM_DIR/v$NODE_VERSION
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 # Set working directory
 WORKDIR /app
 
-USER $user
+CMD ["php", "artisan", "serve", "--host=0.0.0.0"]
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libonig-dev \
     libxml2-dev \
+    nano \
     zip \
     unzip
 

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,57 @@
-# Makefile
-
-# Define the Docker Compose service name
 SERVICE_NAME = app
-
-# Define the Docker Compose command
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker compose
+DOCKER_COMPOSE_RUN = docker compose run --rm $(SERVICE_NAME)
 
 # Define the commands to run inside the Docker Compose service
-COMPOSER_INSTALL = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) composer install
-COMPOSER_UPDATE = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) composer update
-ARTISAN_DB = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) php artisan db
-ARTISAN_KEY_GENERATE = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) php artisan key:generate
-ARTISAN_MIGRATE = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) php artisan migrate
-ARTISAN_MIGRATE_FRESH_SEED = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) php artisan migrate:fresh --seed
-ARTISAN_DB_SEED = $(DOCKER_COMPOSE) exec $(SERVICE_NAME) php artisan db:seed
+COMPOSER_INSTALL = $(DOCKER_COMPOSE_RUN) composer install
+NPM_INSTALL = $(DOCKER_COMPOSE_RUN) npm install
+NPM_BUILD = $(DOCKER_COMPOSE_RUN) npm run build
+COMPOSER_UPDATE = $(DOCKER_COMPOSE_RUN) composer update
+
+ARTISAN_DB = $(DOCKER_COMPOSE_RUN) php artisan db
+ARTISAN_KEY_GENERATE = $(DOCKER_COMPOSE_RUN) php artisan key:generate
+ARTISAN_MIGRATE = $(DOCKER_COMPOSE_RUN) php artisan migrate
+ARTISAN_MIGRATE_FRESH_SEED = $(DOCKER_COMPOSE_RUN) php artisan migrate:fresh --seed
+ARTISAN_DB_SEED = $(DOCKER_COMPOSE_RUN) php artisan db:seed
+ARTISAN_SERVE = $(DOCKER_COMPOSE_RUN) php artisan serve --host=0.0.0.0
 
 # Define the default target
 all: install
 
+init:
+	@test -f .env || cp .env.example .env
+	$(DOCKER_COMPOSE) down --remove-orphans
+	@make install
+	$(ARTISAN_KEY_GENERATE)
+	$(NPM_BUILD)
+	$(ARTISAN_MIGRATE)
+	$(ARTISAN_MIGRATE_FRESH_SEED)
+
+up:
+	$(DOCKER_COMPOSE) down --remove-orphans
+	$(DOCKER_COMPOSE) build
+	$(DOCKER_COMPOSE) up -d
+
+frontend:
+	$(NPM_BUILD)
+
+ssh:
+	$(DOCKER_COMPOSE) run $(SERVICE_NAME) /bin/bash
+
 # Define targets for each command
 install:
+	$(DOCKER_COMPOSE) build
 	$(COMPOSER_INSTALL)
+	$(NPM_INSTALL)
+
+build:
+	$(DOCKER_COMPOSE) build
+
+npm:
+	$(NPM_INSTALL)
 
 update:
 	$(COMPOSER_UPDATE)
-
-key-generate:
-	$(ARTISAN_KEY_GENERATE)
 
 migrate:
 	$(ARTISAN_MIGRATE)

--- a/README.md
+++ b/README.md
@@ -21,19 +21,15 @@ Convention & Event Management System for the [EAST Convention](https://www.sachs
 # Installation
 
 ## System requirements
-- PHP Version: see `composer.json`
-- PHP Extensions: see [Laravel documentation](https://laravel.com/docs/deployment#server-requirements)
+- Docker
+- Docker Compose
 
 ## Local installation
 1. Clone git repository
-2. Copy file `.env.example` to `.env`
-3. Add your local database credentials
-4. Run command `composer install` and `npm run build` (or `npm run dev` to listen for any changes)
-5. Generate app key with this command `php artisan key:generate`
-6. (Optional) Test connection with `php artisan db`, when successful, exit with typing `exit`
-7. Create tables in database `php artisan migrate`
-8. (Optional) Fill with testing data `php artisan db:seed` or if you want to refresh the whole database `php artisan migrate:fresh --seed`
-9. run local webserver with `php artisan serve` [`--port=80`]
+2. Run `make init`
+3. (Optional) Test connection with `php artisan db`, when successful, exit with typing `exit`
+4. Run `make up`
+5. Open http://localhost:8000
 
 ## Production
 - Deploy the application and install dependencies

--- a/app/Settings/AppSettings.php
+++ b/app/Settings/AppSettings.php
@@ -52,7 +52,9 @@ class AppSettings extends Settings
     }
 
     public function logoUrl(): string {
-        return Storage::disk("public")->exists("logo.png") ? Storage::disk("public")->url("logo.png") : config("app.url") . "/images/logo.png";
+        return Storage::disk("public")->exists("logo.png")
+            ? Storage::disk("public")->url("logo.png")
+            : config("app.url") . "/images/logo.png";
     }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,10 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
-            args:
-                user: "sigma"
-                uid: "1337"
         volumes:
             - .:/app
         ports:
-            - "443:443"
+            - "8000:8000"
         depends_on:
             - database
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "sigma",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
Closes #169 

@kidran i removed some ports and stuff with just the development system in mind. 
With that PR everybody can pull the repo and just start it, which makes sigma available at localhost:8000

If there is anything needed (like ports) for the prod environment, i suggest to either create a docker-compose.override.yml file or a docker-compose.prod.yml which is then used in production environment.

Noteable changes
- Container runs as root
- Port 443 removed
- Port 8000 added for artisan serve
- Updated Readme
- Composer allowed as root
- App Container now has node
- App Container is fixed to 8.4 since latest (8.5) will throw deprecations